### PR TITLE
refactor/api error struct

### DIFF
--- a/internal/exceptions/api.go
+++ b/internal/exceptions/api.go
@@ -1,21 +1,25 @@
 package exceptions
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+)
 
 type ApiError struct {
-	Message string `json:"error"`
-	Status  int    `json:"status"`
+	Err    any `json:"error"`
+	Status int `json:"status"`
 }
 
 func NewApiError(status int, message string) *ApiError {
 	return &ApiError{
-		Message: message,
-		Status:  status,
+		Err:    message,
+		Status: status,
 	}
 }
 
 func (ae *ApiError) Error() string {
-	return ae.Message
+	data, _ := json.Marshal(ae.Err)
+	return string(data)
 }
 
 func BadRequest(message string) *ApiError {

--- a/internal/exceptions/api.go
+++ b/internal/exceptions/api.go
@@ -10,9 +10,9 @@ type ApiError struct {
 	Status int `json:"status"`
 }
 
-func NewApiError(status int, message string) *ApiError {
+func NewApiError(status int, errors any) *ApiError {
 	return &ApiError{
-		Err:    message,
+		Err:    errors,
 		Status: status,
 	}
 }

--- a/internal/http/controller/controller.go
+++ b/internal/http/controller/controller.go
@@ -49,7 +49,7 @@ func (c *Context) ParseBody(v schemas.Validatable) error {
 		return exceptions.UnprocessableEntity("invalid body")
 	}
 	if err := v.Validate(); err != nil {
-		return err
+		return exceptions.NewApiError(http.StatusUnprocessableEntity, err)
 	}
 	return nil
 }

--- a/internal/http/controller/routes.go
+++ b/internal/http/controller/routes.go
@@ -47,8 +47,8 @@ func useHandler(fn ControllerFunc) http.HandlerFunc {
 func handleApiErr(ctx *Context, err error) error {
 	slog.Error(err.Error())
 	apiErr := &exceptions.ApiError{
-		Status:  http.StatusInternalServerError,
-		Message: "internal server error",
+		Status: http.StatusInternalServerError,
+		Err:    "internal server error",
 	}
 	validationErr := &validate.ValidationError{}
 	if errors.As(err, &validationErr) {

--- a/internal/validate/validation.go
+++ b/internal/validate/validation.go
@@ -7,7 +7,7 @@ import (
 
 type ValidationError map[string][]string
 
-func (ve *ValidationError) Error() string {
+func (ve ValidationError) Error() string {
 	errBytes, _ := json.Marshal(ve)
 	return string(errBytes)
 }
@@ -25,5 +25,5 @@ func Rules(err ...error) error {
 	if len(validationError) == 0 {
 		return nil
 	}
-	return &validationError
+	return validationError
 }


### PR DESCRIPTION
- **refactor: make api error struct receive any instead of a string**
- **refactor: remove api error struct pointer from error method**
